### PR TITLE
Jacoco achievement_service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,11 +64,6 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.2")
     testImplementation("org.assertj:assertj-core:3.24.2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-
-    /**
-     * Swagger
-     */
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0")
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,11 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.2")
     testImplementation("org.assertj:assertj-core:3.24.2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    /**
+     * Swagger
+     */
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0")
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,12 @@ plugins {
     java
     id("org.springframework.boot") version "3.0.6"
     id("io.spring.dependency-management") version "1.1.0"
+    jacoco
+}
+
+jacoco {
+    toolVersion = "0.8.9"
+    reportsDirectory.set(layout.buildDirectory.dir("jacocoReports"))
 }
 
 group = "faang.school"
@@ -62,6 +68,19 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+tasks.test {
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(false)
+        csv.required.set(false)
+        html.outputLocation.set(layout.buildDirectory.dir("jacocoHtml"))
+    }
 }
 
 val test by tasks.getting(Test::class) { testLogging.showStandardStreams = true }

--- a/src/main/java/faang/school/achievement/AchievementServiceApp.java
+++ b/src/main/java/faang/school/achievement/AchievementServiceApp.java
@@ -2,9 +2,6 @@ package faang.school.achievement;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.info.Contact;
-import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.Banner;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -17,17 +14,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @EnableFeignClients("faang.school.achievement.client")
 @EnableAsync
 @EnableRetry
-@OpenAPIDefinition(
-        info = @Info(
-                title = "Achievement Service",
-                version = "1.0.0",
-                description = "OpenApi documentation for Achievement Service",
-                contact = @Contact(
-                        name = "Faang School",
-                        url = "https://faang.school"
-                )
-        )
-)
 public class AchievementServiceApp {
     public static void main(String[] args) {
         new SpringApplicationBuilder(AchievementServiceApp.class)

--- a/src/main/java/faang/school/achievement/AchievementServiceApp.java
+++ b/src/main/java/faang/school/achievement/AchievementServiceApp.java
@@ -2,6 +2,9 @@ package faang.school.achievement;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.Banner;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -14,6 +17,17 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @EnableFeignClients("faang.school.achievement.client")
 @EnableAsync
 @EnableRetry
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Achievement Service",
+                version = "1.0.0",
+                description = "OpenApi documentation for Achievement Service",
+                contact = @Contact(
+                        name = "Faang School",
+                        url = "https://faang.school"
+                )
+        )
+)
 public class AchievementServiceApp {
     public static void main(String[] args) {
         new SpringApplicationBuilder(AchievementServiceApp.class)


### PR DESCRIPTION
Хоетл бы узнать как игнорировать package которые не нужно проверять на покрытость при тестах.
Писал 
tasks.jacocoTestCoverageVerification {
    dependsOn(tasks.test)
    violationRules {
        rule {
            element = "PACKAGE"
            excludes = listOf("faang.school.achievement.client*", "faang.school.achievement.config.*",
                    "faang.schoo.achievementl.dto.*", "faang.school.achievement.model.*",
                    "faang.school.achievement.repository.*")
            limit {
                minimum = "0.8".toBigDecimal()
            }
        }
    }
}
Но оно всеравно учитывает их почему то