### PR TITLE
[BJS2-41712] - publication of achievements

### DIFF
--- a/src/main/java/faang/school/achievement/config/redis/RedisConfig.java
+++ b/src/main/java/faang/school/achievement/config/redis/RedisConfig.java
@@ -1,0 +1,50 @@
+package faang.school.achievement.config.redis;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "spring.data.redis")
+public class RedisConfig {
+
+    @Getter
+    @Setter
+    public static class Channel {
+        private String achievement;
+        private String follower;
+    }
+
+    private String host;
+    private int port;
+    private Channel channel;
+
+    @Bean
+    public JedisConnectionFactory jedisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(host, port);
+        return new JedisConnectionFactory(redisConfig);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(jedisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());// ???????
+        return template;
+    }
+
+    @Bean
+    ChannelTopic achievementTopic() {
+        return new ChannelTopic(this.channel.achievement);
+    }
+}

--- a/src/main/java/faang/school/achievement/controller/TestController.java
+++ b/src/main/java/faang/school/achievement/controller/TestController.java
@@ -1,0 +1,21 @@
+package faang.school.achievement.controller;
+
+import faang.school.achievement.dto.redisevent.AchievementEvent;
+import faang.school.achievement.publisher.AchievementPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("test")
+@RestController
+@RequiredArgsConstructor
+public class TestController {
+    private final AchievementPublisher achievementPublisher;
+
+    @PutMapping("/api/achievement-service/event")
+    public void sendEvent(@RequestBody AchievementEvent event) {
+        achievementPublisher.publish(event);
+    }
+}

--- a/src/main/java/faang/school/achievement/dto/redisevent/AchievementEvent.java
+++ b/src/main/java/faang/school/achievement/dto/redisevent/AchievementEvent.java
@@ -1,0 +1,13 @@
+package faang.school.achievement.dto.redisevent;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AchievementEvent {
+    private long userId;
+    private String achievement;
+}

--- a/src/main/java/faang/school/achievement/publisher/AchievementPublisher.java
+++ b/src/main/java/faang/school/achievement/publisher/AchievementPublisher.java
@@ -1,0 +1,33 @@
+package faang.school.achievement.publisher;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faang.school.achievement.dto.redisevent.AchievementEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AchievementPublisher implements MessagePublisher<AchievementEvent> {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ChannelTopic achievementTopic;
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Class<?> getInstance() {
+        return AchievementEvent.class;
+    }
+
+    @Override
+    public void publish(AchievementEvent event) {
+        try {
+            String json = objectMapper.writeValueAsString(event);
+            redisTemplate.convertAndSend(achievementTopic.getTopic(), json);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/faang/school/achievement/publisher/MessagePublisher.java
+++ b/src/main/java/faang/school/achievement/publisher/MessagePublisher.java
@@ -1,0 +1,6 @@
+package faang.school.achievement.publisher;
+
+public interface MessagePublisher <T> {
+    Class<?> getInstance();
+    void publish(T event);
+}


### PR DESCRIPTION
Задание
Когда achievement_service выдает любому пользователю любое достижение, то это ведь большое событие в системе! Вероятно, другие сервисы захотят о нём узнать. Например, notification_service мог бы быть заинтересован в таком событии и отправить получателю достижения нотификацию об этом.

Поэтому achievement_service должен уметь публиковать в Redis топик событие каждый раз, когда выдает кому-либо любое достижение. Для этого нужно создать необходимую Spring-конфигурацию и сделать специальный компонент AchievementPublisher, который и будет заниматься публикацией события о достижении пользователя.

В сервисе реализован функционал, который отправляет через redis сообщения. Функционал, который принимает  сообщения, реализован в сервисе notification_service. Его смотреть нужно здесь: https://github.com/CorporationX/notification_service/pull/418

![redis_postman](https://github.com/user-attachments/assets/c0374592-60f5-4193-99fb-018569de23f8)

![redis_mail](https://github.com/user-attachments/assets/9ee4f7de-12e5-4ec3-b753-11091db840d7)
