### PR TITLE
Добавил логику кеширования достижений, изменил репозиторий с crud на JPA, изменил коллекции в сущностях с List на Set

### DIFF
--- a/src/main/java/faang/school/achievement/cache/AchievementCache.java
+++ b/src/main/java/faang/school/achievement/cache/AchievementCache.java
@@ -1,0 +1,31 @@
+package faang.school.achievement.cache;
+
+import faang.school.achievement.model.Achievement;
+import faang.school.achievement.repository.AchievementRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class AchievementCache {
+    private final AchievementRepository achievementRepository;
+    private Map<String, Achievement> achievements;
+
+    public Achievement get(String title) {
+        return achievements.get(title);
+    }
+
+    @PostConstruct
+    @Transactional
+    public void init() {
+        achievements = achievementRepository.findAllWithLazyCollections()
+                .stream()
+                .collect(Collectors.toMap(Achievement::getTitle, Function.identity()));
+    }
+}

--- a/src/main/java/faang/school/achievement/model/Achievement.java
+++ b/src/main/java/faang/school/achievement/model/Achievement.java
@@ -18,7 +18,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Set;
 
 @Data
 @AllArgsConstructor
@@ -43,10 +43,10 @@ public class Achievement {
     private Rarity rarity;
 
     @OneToMany(mappedBy = "achievement")
-    private List<UserAchievement> userAchievements;
+    private Set<UserAchievement> userAchievements;
 
     @OneToMany(mappedBy = "achievement")
-    private List<AchievementProgress> progresses;
+    private Set<AchievementProgress> progresses;
 
     @Column(name = "points", nullable = false)
     private long points;

--- a/src/main/java/faang/school/achievement/repository/AchievementRepository.java
+++ b/src/main/java/faang/school/achievement/repository/AchievementRepository.java
@@ -1,9 +1,19 @@
 package faang.school.achievement.repository;
 
 import faang.school.achievement.model.Achievement;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Set;
+
 @Repository
-public interface AchievementRepository extends CrudRepository<Achievement, Long> {
+public interface AchievementRepository extends JpaRepository<Achievement, Long> {
+
+    @Query(value = """
+            FROM Achievement a
+            """)
+    @EntityGraph(attributePaths = {"userAchievements", "progresses"})
+    Set<Achievement> findAllWithLazyCollections();
 }

--- a/src/test/java/faang/school/achievement/cache/AchievementCacheTest.java
+++ b/src/test/java/faang/school/achievement/cache/AchievementCacheTest.java
@@ -1,0 +1,68 @@
+package faang.school.achievement.cache;
+
+import faang.school.achievement.model.Achievement;
+import faang.school.achievement.repository.AchievementRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AchievementCacheTest {
+
+    @Mock
+    private AchievementRepository achievementRepository;
+
+    @InjectMocks
+    private AchievementCache achievementCache;
+
+    private Achievement achievement;
+
+    @BeforeEach
+    void setUp() {
+        achievement = Achievement.builder()
+                .id(1L)
+                .title("Achievement 1")
+                .description("Description 1")
+                .points(100)
+                .build();
+        Set<Achievement> achievements = Set.of(achievement);
+        when(achievementRepository.findAllWithLazyCollections()).thenReturn(achievements);
+        achievementCache.init();
+    }
+
+    @Test
+    void testGet() {
+        Achievement cachedAchievement = achievementCache.get("Achievement 1");
+        assertThat(cachedAchievement)
+                .isEqualTo(achievement);
+    }
+
+    @Test
+    void testInit() {
+        Achievement achievement2 = Achievement.builder()
+                .id(2L)
+                .title("Achievement 2")
+                .description("Description 2")
+                .points(200)
+                .build();
+        Set<Achievement> achievements = Set.of(achievement, achievement2);
+
+        when(achievementRepository.findAllWithLazyCollections()).thenReturn(achievements);
+        achievementCache.init();
+
+        Achievement cachedAchievement1 = achievementCache.get("Achievement 1");
+        Achievement cachedAchievement2 = achievementCache.get("Achievement 2");
+        Set<Achievement> cachedAchievements = Set.of(cachedAchievement1, cachedAchievement2);
+
+        assertThat(cachedAchievements)
+                .isEqualTo(achievements);
+    }
+}


### PR DESCRIPTION
Добавлена возможность получения кешированного достижения через метод get AchievementCache (достижения хранит в себе потенциально устаревшие UserAchievement и AchievementProgress (тема для обсуждения))

Изменена реализация AchievementRepository с CRUD на Jpa, для возможности единовременного запроса связанных сущностей

Изменены коллекции в сущности Achievement c List на Set (для возможности запроса их через граф)

Основные изменения по сущности и репозиторию сделаны для избегания LazyInitializationException