### PR TITLE
"Добавить настройку Kafka Consumer, реализовать обработку ивентов из …

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-consul-config")
     implementation("org.springframework.cloud:spring-cloud-starter-consul-discovery")
     implementation("org.springframework.retry:spring-retry")
+    implementation("org.springframework.kafka:spring-kafka")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
     /**

--- a/src/main/java/faang/school/achievement/AchievementServiceApp.java
+++ b/src/main/java/faang/school/achievement/AchievementServiceApp.java
@@ -1,6 +1,8 @@
 package faang.school.achievement;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.boot.Banner;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -22,6 +24,8 @@ public class AchievementServiceApp {
 
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 }

--- a/src/main/java/faang/school/achievement/config/context/UserHeaderFilter.java
+++ b/src/main/java/faang/school/achievement/config/context/UserHeaderFilter.java
@@ -1,10 +1,6 @@
 package faang.school.achievement.config.context;
 
-import jakarta.servlet.Filter;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
+import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/faang/school/achievement/config/kafka/KafkaConfig.java
+++ b/src/main/java/faang/school/achievement/config/kafka/KafkaConfig.java
@@ -1,0 +1,76 @@
+package faang.school.achievement.config.kafka;
+
+import faang.school.achievement.kafka.events.CommentAddedEvent;
+import faang.school.achievement.kafka.events.GoalCompletedEvent;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class KafkaConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    private final KafkaConsumerSettings kafkaProperties;
+
+    @Value("${spring.kafka.consumers.comment-added.name}")
+    private String commentAddedSettingsKey;
+
+    @Value("${spring.kafka.consumers.goal-completed.name}")
+    private String goalCompletedSettingsKey;
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, CommentAddedEvent>
+    commentAddedEventKafkaListenerContainerFactory() {
+        return buildFactory(CommentAddedEvent.class, commentAddedSettingsKey);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, GoalCompletedEvent>
+    goalCompletedEventKafkaListenerContainerFactory() {
+        return buildFactory(GoalCompletedEvent.class, goalCompletedSettingsKey);
+    }
+
+    public <T> ConcurrentKafkaListenerContainerFactory<String, T> buildFactory(
+            Class<T> valueType,
+            String consumerKey
+    ) {
+        var settings = kafkaProperties.getConsumers().get(consumerKey);
+        if (settings == null) {
+            throw new IllegalArgumentException("No settings for key: " + consumerKey);
+        }
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, settings.getGroupId());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, settings.getOffsetResetConfig());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, valueType.getName());
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, settings.getMaxPollRecords());
+
+        ConsumerFactory<String, T> consumerFactory = new DefaultKafkaConsumerFactory<>(props);
+
+        var factory = new ConcurrentKafkaListenerContainerFactory<String, T>();
+        factory.setConsumerFactory(consumerFactory);
+        factory.setConcurrency(settings.getConcurrency());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.valueOf(settings.getAckMode()));
+
+        return factory;
+    }
+}

--- a/src/main/java/faang/school/achievement/config/kafka/KafkaConfig.java
+++ b/src/main/java/faang/school/achievement/config/kafka/KafkaConfig.java
@@ -61,7 +61,7 @@ public class KafkaConfig {
         props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, valueType.getName());
         props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
         props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
-        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, true);
         props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, settings.getMaxPollRecords());
 
         ConsumerFactory<String, T> consumerFactory = new DefaultKafkaConsumerFactory<>(props);

--- a/src/main/java/faang/school/achievement/config/kafka/KafkaConsumerSettings.java
+++ b/src/main/java/faang/school/achievement/config/kafka/KafkaConsumerSettings.java
@@ -1,0 +1,36 @@
+package faang.school.achievement.config.kafka;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@ConfigurationProperties(prefix = "spring.kafka")
+@Getter
+@Setter
+@Validated
+public class KafkaConsumerSettings {
+    Map<String, ConsumerProperties> consumers = new HashMap<>();
+
+    @Getter
+    @Setter
+    public static class ConsumerProperties {
+        @NotBlank
+        private String groupId;
+        @NotBlank
+        private String ackMode;
+        @Min(1)
+        private int concurrency;
+        @Min(1)
+        private int maxPollRecords;
+        @NotBlank
+        private String offsetResetConfig;
+    }
+}

--- a/src/main/java/faang/school/achievement/config/redis/RedisConfig.java
+++ b/src/main/java/faang/school/achievement/config/redis/RedisConfig.java
@@ -1,0 +1,71 @@
+package faang.school.achievement.config.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faang.school.achievement.model.Achievement;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    @Primary
+    public RedisConnectionFactory redisConnectionFactory(@Value("${spring.data.redis.host}") String host,
+                                                         @Value("${spring.data.redis.port}") int port) {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(host);
+        config.setPort(port);
+        return new JedisConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<String, Achievement> redisAchievementTemplate(RedisConnectionFactory factory,
+                                                                       ObjectMapper objectMapper) {
+        RedisTemplate<String, Achievement> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        Jackson2JsonRedisSerializer<Achievement> serializer =
+                new Jackson2JsonRedisSerializer<>(objectMapper, Achievement.class);
+        template.setValueSerializer(serializer);
+        template.afterPropertiesSet();
+        template.setHashValueSerializer(serializer);
+        return template;
+    }
+
+    @Bean
+    @Primary
+    public RedisTemplate<String, String> redisStringTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+        template.afterPropertiesSet();
+
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, Long> redisCounterTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Long> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
+        template.setHashValueSerializer(new GenericToStringSerializer<>(Long.class));
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/faang/school/achievement/config/redis/RedisConfig.java
+++ b/src/main/java/faang/school/achievement/config/redis/RedisConfig.java
@@ -43,7 +43,6 @@ public class RedisConfig {
     }
 
     @Bean
-    @Primary
     public RedisTemplate<String, String> redisStringTemplate(RedisConnectionFactory factory) {
         RedisTemplate<String, String> template = new RedisTemplate<>();
         template.setConnectionFactory(factory);

--- a/src/main/java/faang/school/achievement/dto/AchievementDto.java
+++ b/src/main/java/faang/school/achievement/dto/AchievementDto.java
@@ -1,0 +1,15 @@
+package faang.school.achievement.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AchievementDto {
+    private long id;
+    private String title;
+    private String description;
+    private long points;
+}

--- a/src/main/java/faang/school/achievement/dto/AchievementProgressRecord.java
+++ b/src/main/java/faang/school/achievement/dto/AchievementProgressRecord.java
@@ -1,0 +1,6 @@
+package faang.school.achievement.dto;
+
+import faang.school.achievement.model.Achievement;
+
+public record AchievementProgressRecord(Achievement achievement, long userId, long currentPoints) {
+}

--- a/src/main/java/faang/school/achievement/exceptions/ObjectAlreadyExistsException.java
+++ b/src/main/java/faang/school/achievement/exceptions/ObjectAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package faang.school.achievement.exceptions;
+
+public class ObjectAlreadyExistsException extends RuntimeException {
+    public ObjectAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/faang/school/achievement/exceptions/ObjectNotFoundException.java
+++ b/src/main/java/faang/school/achievement/exceptions/ObjectNotFoundException.java
@@ -1,0 +1,7 @@
+package faang.school.achievement.exceptions;
+
+public class ObjectNotFoundException extends RuntimeException {
+    public ObjectNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/faang/school/achievement/kafka/events/CommentAddedEvent.java
+++ b/src/main/java/faang/school/achievement/kafka/events/CommentAddedEvent.java
@@ -1,0 +1,11 @@
+package faang.school.achievement.kafka.events;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class CommentAddedEvent extends Event {
+}

--- a/src/main/java/faang/school/achievement/kafka/events/Event.java
+++ b/src/main/java/faang/school/achievement/kafka/events/Event.java
@@ -1,0 +1,19 @@
+package faang.school.achievement.kafka.events;
+
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@SuperBuilder
+public abstract class Event {
+    private UUID id;
+    private LocalDateTime occurredAt;
+    private String source;
+    private String eventType;
+    private Long authorId;
+    private Long receiverId;
+    private Long userId;
+}

--- a/src/main/java/faang/school/achievement/kafka/events/GoalCompletedEvent.java
+++ b/src/main/java/faang/school/achievement/kafka/events/GoalCompletedEvent.java
@@ -1,0 +1,11 @@
+package faang.school.achievement.kafka.events;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class GoalCompletedEvent extends Event {
+}

--- a/src/main/java/faang/school/achievement/kafka/listeners/AbstractEventListener.java
+++ b/src/main/java/faang/school/achievement/kafka/listeners/AbstractEventListener.java
@@ -1,0 +1,40 @@
+package faang.school.achievement.kafka.listeners;
+
+import faang.school.achievement.kafka.events.Event;
+import faang.school.achievement.service.handlers.events.EventHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Slf4j
+public class AbstractEventListener<T extends Event> implements EventListener<T> {
+    private final Map<Class<? extends Event>, List<EventHandler>> handlersMap;
+
+    public AbstractEventListener(List<EventHandler> handlers) {
+        this.handlersMap = handlers.stream()
+                .flatMap(handler -> handler.getEventTypes().stream()
+                        .map(type -> Map.entry(type, handler)))
+                .collect(Collectors.groupingBy(
+                        Map.Entry::getKey,
+                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())
+                ));
+    }
+
+    @Override
+    public void handle(ConsumerRecord<String, T> message) {
+        log.info("Handling message: {}", message);
+        T value = message.value();
+        List<EventHandler> handlers = handlersMap.get(value.getClass());
+
+        if (handlers != null) {
+            handlers.forEach(handler -> handler.handle(value));
+        } else {
+            log.warn("No handlers found for event type: {}", value.getClass().getSimpleName());
+        }
+    }
+}

--- a/src/main/java/faang/school/achievement/kafka/listeners/CommentAddedEventListener.java
+++ b/src/main/java/faang/school/achievement/kafka/listeners/CommentAddedEventListener.java
@@ -5,7 +5,6 @@ import faang.school.achievement.service.handlers.events.EventHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -22,9 +21,8 @@ public class CommentAddedEventListener extends AbstractEventListener<CommentAdde
             topics = "${spring.kafka.topics.comment-added.name}",
             containerFactory = "commentAddedEventKafkaListenerContainerFactory"
     )
-    public void listen(ConsumerRecord<String, CommentAddedEvent> message, Acknowledgment ack) {
+    public void listen(ConsumerRecord<String, CommentAddedEvent> message) {
         log.info("Received comment added event, message: {} ", message);
         handle(message);
-        ack.acknowledge();
     }
 }

--- a/src/main/java/faang/school/achievement/kafka/listeners/CommentAddedEventListener.java
+++ b/src/main/java/faang/school/achievement/kafka/listeners/CommentAddedEventListener.java
@@ -1,0 +1,30 @@
+package faang.school.achievement.kafka.listeners;
+
+import faang.school.achievement.kafka.events.CommentAddedEvent;
+import faang.school.achievement.service.handlers.events.EventHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Slf4j
+public class CommentAddedEventListener extends AbstractEventListener<CommentAddedEvent> {
+
+    public CommentAddedEventListener(List<EventHandler> handlers) {
+        super(handlers);
+    }
+
+    @KafkaListener(
+            topics = "${spring.kafka.topics.comment-added.name}",
+            containerFactory = "commentAddedEventKafkaListenerContainerFactory"
+    )
+    public void listen(ConsumerRecord<String, CommentAddedEvent> message, Acknowledgment ack) {
+        log.info("Received comment added event, message: {} ", message);
+        handle(message);
+        ack.acknowledge();
+    }
+}

--- a/src/main/java/faang/school/achievement/kafka/listeners/EventListener.java
+++ b/src/main/java/faang/school/achievement/kafka/listeners/EventListener.java
@@ -1,0 +1,8 @@
+package faang.school.achievement.kafka.listeners;
+
+import faang.school.achievement.kafka.events.Event;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public interface EventListener<T extends Event> {
+    void handle(ConsumerRecord<String, T> message);
+}

--- a/src/main/java/faang/school/achievement/kafka/listeners/GoalCompletedEventListener.java
+++ b/src/main/java/faang/school/achievement/kafka/listeners/GoalCompletedEventListener.java
@@ -5,7 +5,6 @@ import faang.school.achievement.service.handlers.events.EventHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -22,9 +21,8 @@ public class GoalCompletedEventListener extends AbstractEventListener<GoalComple
             topics = "${spring.kafka.topics.goal-completed.name}",
             containerFactory = "goalCompletedEventKafkaListenerContainerFactory"
     )
-    public void listen(ConsumerRecord<String, GoalCompletedEvent> message, Acknowledgment ack) {
+    public void listen(ConsumerRecord<String, GoalCompletedEvent> message) {
         log.info("Received goal completed event, message: {} ", message);
         handle(message);
-        ack.acknowledge();
     }
 }

--- a/src/main/java/faang/school/achievement/kafka/listeners/GoalCompletedEventListener.java
+++ b/src/main/java/faang/school/achievement/kafka/listeners/GoalCompletedEventListener.java
@@ -1,0 +1,30 @@
+package faang.school.achievement.kafka.listeners;
+
+import faang.school.achievement.kafka.events.GoalCompletedEvent;
+import faang.school.achievement.service.handlers.events.EventHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Slf4j
+public class GoalCompletedEventListener extends AbstractEventListener<GoalCompletedEvent> {
+
+    public GoalCompletedEventListener(List<EventHandler> handlers) {
+        super(handlers);
+    }
+
+    @KafkaListener(
+            topics = "${spring.kafka.topics.goal-completed.name}",
+            containerFactory = "goalCompletedEventKafkaListenerContainerFactory"
+    )
+    public void listen(ConsumerRecord<String, GoalCompletedEvent> message, Acknowledgment ack) {
+        log.info("Received goal completed event, message: {} ", message);
+        handle(message);
+        ack.acknowledge();
+    }
+}

--- a/src/main/java/faang/school/achievement/mapper/AchievementMapper.java
+++ b/src/main/java/faang/school/achievement/mapper/AchievementMapper.java
@@ -22,6 +22,5 @@ public interface AchievementMapper {
     @Mapping(target = "updatedAt", ignore = true)
     UserAchievement toUserAchievement(AchievementProgressRecord achievement);
 
-
     AchievementDto toAchievementDto(Achievement achievement);
 }

--- a/src/main/java/faang/school/achievement/mapper/AchievementMapper.java
+++ b/src/main/java/faang/school/achievement/mapper/AchievementMapper.java
@@ -1,0 +1,27 @@
+package faang.school.achievement.mapper;
+
+import faang.school.achievement.dto.AchievementDto;
+import faang.school.achievement.dto.AchievementProgressRecord;
+import faang.school.achievement.model.Achievement;
+import faang.school.achievement.model.AchievementProgress;
+import faang.school.achievement.model.UserAchievement;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface AchievementMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "version", ignore = true)
+    AchievementProgress toAchievement(AchievementProgressRecord achievement);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    UserAchievement toUserAchievement(AchievementProgressRecord achievement);
+
+
+    AchievementDto toAchievementDto(Achievement achievement);
+}

--- a/src/main/java/faang/school/achievement/model/Achievement.java
+++ b/src/main/java/faang/school/achievement/model/Achievement.java
@@ -44,12 +44,10 @@ public class Achievement {
     private Rarity rarity;
 
     @OneToMany(mappedBy = "achievement")
-    @JsonManagedReference
     @ToStringExclude
     private List<UserAchievement> userAchievements;
 
     @OneToMany(mappedBy = "achievement")
-    @JsonManagedReference
     @ToStringExclude
     private List<AchievementProgress> progresses;
 

--- a/src/main/java/faang/school/achievement/model/Achievement.java
+++ b/src/main/java/faang/school/achievement/model/Achievement.java
@@ -1,19 +1,12 @@
 package faang.school.achievement.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.builder.ToStringExclude;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -25,7 +18,15 @@ import java.util.List;
 @NoArgsConstructor
 @Builder
 @Entity
-@Table(name="achievement")
+@Table(name = "achievement")
+@NamedEntityGraph(name = "achievement.userAchievements",
+        attributeNodes = {
+                @NamedAttributeNode("userAchievements"),
+        })
+@NamedEntityGraph(name = "achievement.progresses",
+        attributeNodes = {
+                @NamedAttributeNode("progresses"),
+        })
 public class Achievement {
 
     @Id
@@ -43,9 +44,13 @@ public class Achievement {
     private Rarity rarity;
 
     @OneToMany(mappedBy = "achievement")
+    @JsonManagedReference
+    @ToStringExclude
     private List<UserAchievement> userAchievements;
 
     @OneToMany(mappedBy = "achievement")
+    @JsonManagedReference
+    @ToStringExclude
     private List<AchievementProgress> progresses;
 
     @Column(name = "points", nullable = false)

--- a/src/main/java/faang/school/achievement/model/AchievementCode.java
+++ b/src/main/java/faang/school/achievement/model/AchievementCode.java
@@ -1,0 +1,22 @@
+package faang.school.achievement.model;
+
+public enum AchievementCode {
+    COLLECTOR("COLLECTOR"),
+    MR_PRODUCTIVITY("MR PRODUCTIVITY"),
+    EXPERT("EXPERT"),
+    SENSEI("SENSEI"),
+    MANAGER("MANAGER"),
+    CELEBRITY("CELEBRITY"),
+    WRITER("WRITER"),
+    HANDSOME("HANDSOME");
+
+    private final String name;
+
+    public String getName() {
+        return name;
+    }
+
+    AchievementCode(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/faang/school/achievement/model/AchievementProgress.java
+++ b/src/main/java/faang/school/achievement/model/AchievementProgress.java
@@ -1,11 +1,13 @@
 package faang.school.achievement.model;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.builder.ToStringExclude;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -25,7 +27,8 @@ public class AchievementProgress {
 
     @ManyToOne
     @JoinColumn(name = "achievement_id", nullable = false)
-    @JsonBackReference
+    @JsonIgnore
+    @ToStringExclude
     private Achievement achievement;
 
     @Column(name = "user_id", nullable = false)

--- a/src/main/java/faang/school/achievement/model/AchievementProgress.java
+++ b/src/main/java/faang/school/achievement/model/AchievementProgress.java
@@ -1,16 +1,7 @@
 package faang.school.achievement.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
-import jakarta.persistence.Version;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -25,7 +16,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 @Entity
-@Table(name="user_achievement_progress")
+@Table(name = "user_achievement_progress")
 public class AchievementProgress {
 
     @Id
@@ -34,6 +25,7 @@ public class AchievementProgress {
 
     @ManyToOne
     @JoinColumn(name = "achievement_id", nullable = false)
+    @JsonBackReference
     private Achievement achievement;
 
     @Column(name = "user_id", nullable = false)

--- a/src/main/java/faang/school/achievement/model/UserAchievement.java
+++ b/src/main/java/faang/school/achievement/model/UserAchievement.java
@@ -1,11 +1,13 @@
 package faang.school.achievement.model;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.builder.ToStringExclude;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -25,7 +27,8 @@ public class UserAchievement {
 
     @ManyToOne
     @JoinColumn(name = "achievement_id", nullable = false)
-    @JsonBackReference
+    @JsonIgnore
+    @ToStringExclude
     private Achievement achievement;
 
     @Column(name = "user_id", nullable = false)

--- a/src/main/java/faang/school/achievement/model/UserAchievement.java
+++ b/src/main/java/faang/school/achievement/model/UserAchievement.java
@@ -1,15 +1,7 @@
 package faang.school.achievement.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -24,7 +16,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 @Entity
-@Table(name="user_achievement")
+@Table(name = "user_achievement")
 public class UserAchievement {
 
     @Id
@@ -33,6 +25,7 @@ public class UserAchievement {
 
     @ManyToOne
     @JoinColumn(name = "achievement_id", nullable = false)
+    @JsonBackReference
     private Achievement achievement;
 
     @Column(name = "user_id", nullable = false)

--- a/src/main/java/faang/school/achievement/redis/AchievementCache.java
+++ b/src/main/java/faang/school/achievement/redis/AchievementCache.java
@@ -5,7 +5,6 @@ import faang.school.achievement.model.Achievement;
 import faang.school.achievement.model.AchievementCode;
 import faang.school.achievement.repository.AchievementRepository;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -19,17 +18,17 @@ import java.util.concurrent.TimeUnit;
 @Component
 @Slf4j
 public class AchievementCache {
-    private final RedisTemplate<String, Achievement> redisStringTemplate;
+    private final RedisTemplate<String, Achievement> redisAchievementTemplate;
     private final AchievementKeyBuilder achievementKeyBuilder;
     private final AchievementRepository achievementRepository;
 
     @Value("${spring.data.redis.achievements.ttl-s}")
     private long achievementKeyTTL;
 
-    public AchievementCache(@Qualifier("redisAchievementTemplate") RedisTemplate<String, Achievement> redisStringTemplate,
+    public AchievementCache(RedisTemplate<String, Achievement> redisAchievementTemplate,
                             AchievementKeyBuilder achievementKeyBuilder,
                             AchievementRepository achievementRepository) {
-        this.redisStringTemplate = redisStringTemplate;
+        this.redisAchievementTemplate = redisAchievementTemplate;
         this.achievementKeyBuilder = achievementKeyBuilder;
         this.achievementRepository = achievementRepository;
     }
@@ -40,7 +39,7 @@ public class AchievementCache {
         List<Achievement> achievements = getAchievements();
         log.info("Loaded achievements list size: {}", achievements.size());
 
-        redisStringTemplate.executePipelined(new SessionCallback<Object>() {
+        redisAchievementTemplate.executePipelined(new SessionCallback<Object>() {
             @Override
             public Object execute(RedisOperations operations) {
                 RedisOperations<String, Achievement> ops = operations;
@@ -62,7 +61,7 @@ public class AchievementCache {
     }
 
     public Achievement getAchievementByCode(AchievementCode achievementCode) {
-        Achievement cachedAchievement = redisStringTemplate.opsForValue()
+        Achievement cachedAchievement = redisAchievementTemplate.opsForValue()
                 .get(achievementKeyBuilder.achievementKey(achievementCode.getName()));
         if (cachedAchievement == null) {
             Achievement loadedAchievement = loadAchievementByTitle(achievementCode.getName());
@@ -78,7 +77,7 @@ public class AchievementCache {
     }
 
     private void addToCache(Achievement loadedAchievement) {
-        redisStringTemplate.opsForValue().set(achievementKeyBuilder.achievementKey(loadedAchievement.getTitle()),
+        redisAchievementTemplate.opsForValue().set(achievementKeyBuilder.achievementKey(loadedAchievement.getTitle()),
                 loadedAchievement, achievementKeyTTL, TimeUnit.SECONDS);
     }
 }

--- a/src/main/java/faang/school/achievement/redis/AchievementCache.java
+++ b/src/main/java/faang/school/achievement/redis/AchievementCache.java
@@ -1,0 +1,84 @@
+package faang.school.achievement.redis;
+
+import faang.school.achievement.exceptions.ObjectNotFoundException;
+import faang.school.achievement.model.Achievement;
+import faang.school.achievement.model.AchievementCode;
+import faang.school.achievement.repository.AchievementRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@Slf4j
+public class AchievementCache {
+    private final RedisTemplate<String, Achievement> redisStringTemplate;
+    private final AchievementKeyBuilder achievementKeyBuilder;
+    private final AchievementRepository achievementRepository;
+
+    @Value("${spring.data.redis.achievements.ttl-s}")
+    private long achievementKeyTTL;
+
+    public AchievementCache(@Qualifier("redisAchievementTemplate") RedisTemplate<String, Achievement> redisStringTemplate,
+                            AchievementKeyBuilder achievementKeyBuilder,
+                            AchievementRepository achievementRepository) {
+        this.redisStringTemplate = redisStringTemplate;
+        this.achievementKeyBuilder = achievementKeyBuilder;
+        this.achievementRepository = achievementRepository;
+    }
+
+    @Transactional
+    public void init() {
+        log.info("Achievement Cache init");
+        List<Achievement> achievements = getAchievements();
+        log.info("Loaded achievements list size: {}", achievements.size());
+
+        redisStringTemplate.executePipelined(new SessionCallback<Object>() {
+            @Override
+            public Object execute(RedisOperations operations) {
+                RedisOperations<String, Achievement> ops = operations;
+                for (Achievement achievement : achievements) {
+                    String key = achievementKeyBuilder.achievementKey(achievement.getTitle());
+                    ops.opsForValue().set(key, achievement, achievementKeyTTL, TimeUnit.SECONDS);
+                }
+                return null;
+            }
+        });
+    }
+
+    public List<Achievement> getAchievements() {
+        List<Achievement> allWithUserAchievements = achievementRepository.findAllWithUserAchievements();
+        List<Long> ids = allWithUserAchievements.stream()
+                .map(Achievement::getId)
+                .toList();
+        return achievementRepository.findAllWithProgresses(ids);
+    }
+
+    public Achievement getAchievementByCode(AchievementCode achievementCode) {
+        Achievement cachedAchievement = redisStringTemplate.opsForValue()
+                .get(achievementKeyBuilder.achievementKey(achievementCode.getName()));
+        if (cachedAchievement == null) {
+            Achievement loadedAchievement = loadAchievementByTitle(achievementCode.getName());
+            addToCache(loadedAchievement);
+            return loadedAchievement;
+        }
+        return cachedAchievement;
+    }
+
+    public Achievement loadAchievementByTitle(String title) {
+        return achievementRepository.findByTitle(title).orElseThrow(() ->
+                new ObjectNotFoundException(String.format("Achievement with title %s not found", title)));
+    }
+
+    private void addToCache(Achievement loadedAchievement) {
+        redisStringTemplate.opsForValue().set(achievementKeyBuilder.achievementKey(loadedAchievement.getTitle()),
+                loadedAchievement, achievementKeyTTL, TimeUnit.SECONDS);
+    }
+}

--- a/src/main/java/faang/school/achievement/redis/AchievementKeyBuilder.java
+++ b/src/main/java/faang/school/achievement/redis/AchievementKeyBuilder.java
@@ -1,0 +1,20 @@
+package faang.school.achievement.redis;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class AchievementKeyBuilder {
+    private static final String PREFIX = "achievement";
+
+    public String achievementKey(String title) {
+        return String.format("%s:%s", PREFIX, title);
+    }
+
+    public String userProgress(String title, long userId) {
+        return String.format("%s:%s:user:%d:progress", PREFIX, title, userId);
+    }
+
+    public String assignAchievement(long userId) {
+        return String.format("%s:user:%d:completed", PREFIX, userId);
+    }
+}

--- a/src/main/java/faang/school/achievement/redis/RedisCounterService.java
+++ b/src/main/java/faang/school/achievement/redis/RedisCounterService.java
@@ -15,12 +15,12 @@ public abstract class RedisCounterService {
     private final RedisTemplate<String, String> stringRedisTemplate;
     private final AchievementKeyBuilder achievementKeyBuilder;
 
-    public RedisCounterService(@Qualifier("redisCounterTemplate") RedisTemplate<String, Long> redisCounterTemplate,
-                               @Qualifier("redisTemplate") RedisTemplate<String, String> stringRedisTemplate,
+    public RedisCounterService(RedisTemplate<String, Long> redisCounterTemplate,
+                               RedisTemplate<String, String> redisStringTemplate,
                                AchievementKeyBuilder achievementKeyBuilder) {
         this.redisCounterTemplate = redisCounterTemplate;
         this.achievementKeyBuilder = achievementKeyBuilder;
-        this.stringRedisTemplate = stringRedisTemplate;
+        this.stringRedisTemplate = redisStringTemplate;
     }
 
     @Retryable(

--- a/src/main/java/faang/school/achievement/redis/RedisCounterService.java
+++ b/src/main/java/faang/school/achievement/redis/RedisCounterService.java
@@ -3,7 +3,11 @@ package faang.school.achievement.redis;
 import faang.school.achievement.model.AchievementCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 
 @Slf4j
 public abstract class RedisCounterService {
@@ -19,18 +23,33 @@ public abstract class RedisCounterService {
         this.stringRedisTemplate = stringRedisTemplate;
     }
 
+    @Retryable(
+            retryFor = RedisConnectionFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000, multiplier = 2)
+    )
     public Long incrementCounter(AchievementCode achievementCode, long userId) {
         log.info("Increment counter title: {}, userId = {}", achievementCode.getName(), userId);
         String key = achievementKeyBuilder.userProgress(achievementCode.getName(), userId);
         return redisCounterTemplate.opsForValue().increment(key, 1);
     }
 
+    @Retryable(
+            retryFor = RedisConnectionFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000, multiplier = 2)
+    )
     public void decrementCounter(AchievementCode achievementCode, long userId, long delta) {
         log.info("Decrement counter title: {}, userId = {}", achievementCode.getName(), userId);
         String key = achievementKeyBuilder.userProgress(achievementCode.getName(), userId);
         redisCounterTemplate.opsForValue().decrement(key, delta);
     }
 
+    @Retryable(
+            retryFor = RedisConnectionFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000, multiplier = 2)
+    )
     public void assignAchievement(AchievementCode achievementCode, long userId) {
         log.info("Updating a cache with a completed achievement for a user, title: {}, userId = {}", achievementCode.getName(), userId);
         String key = achievementKeyBuilder.assignAchievement(userId);
@@ -38,12 +57,22 @@ public abstract class RedisCounterService {
         removeAchievementProgressTracking(achievementCode, userId);
     }
 
+    @Retryable(
+            retryFor = RedisConnectionFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000, multiplier = 2)
+    )
     public void removeAchievementProgressTracking(AchievementCode achievementCode, long userId) {
         log.info("Removing tracking of the achievement to a user, title: {}, userId = {}", achievementCode.getName(), userId);
         String key = achievementKeyBuilder.userProgress(achievementCode.getName(), userId);
         stringRedisTemplate.delete(key);
     }
 
+    @Retryable(
+            retryFor = RedisConnectionFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000, multiplier = 2)
+    )
     public Boolean checkIfAchievementAssigned(AchievementCode achievementCode, long userId) {
         log.info("Checking if an achievement has been assigned to a user, title: {}, userId = {}",
                 achievementCode.getName(), userId);
@@ -54,5 +83,20 @@ public abstract class RedisCounterService {
             return isAssigned;
         }
         return false;
+    }
+
+    @Recover
+    public void recover(RedisConnectionFailureException e,
+                        AchievementCode code,
+                        long userId) {
+        log.error("Method failed with params: {}, userId={}", code, userId, e);
+    }
+
+    @Recover
+    public void recoverDecrement(RedisConnectionFailureException e,
+                                 AchievementCode code,
+                                 long userId,
+                                 long delta) {
+        log.error("[DECREMENT] Retry failed: {}, userId={}, delta={}", code, userId, delta, e);
     }
 }

--- a/src/main/java/faang/school/achievement/redis/RedisCounterService.java
+++ b/src/main/java/faang/school/achievement/redis/RedisCounterService.java
@@ -1,0 +1,58 @@
+package faang.school.achievement.redis;
+
+import faang.school.achievement.model.AchievementCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Slf4j
+public abstract class RedisCounterService {
+    private final RedisTemplate<String, Long> redisCounterTemplate;
+    private final RedisTemplate<String, String> stringRedisTemplate;
+    private final AchievementKeyBuilder achievementKeyBuilder;
+
+    public RedisCounterService(@Qualifier("redisCounterTemplate") RedisTemplate<String, Long> redisCounterTemplate,
+                               @Qualifier("redisTemplate") RedisTemplate<String, String> stringRedisTemplate,
+                               AchievementKeyBuilder achievementKeyBuilder) {
+        this.redisCounterTemplate = redisCounterTemplate;
+        this.achievementKeyBuilder = achievementKeyBuilder;
+        this.stringRedisTemplate = stringRedisTemplate;
+    }
+
+    public Long incrementCounter(AchievementCode achievementCode, long userId) {
+        log.info("Increment counter title: {}, userId = {}", achievementCode.getName(), userId);
+        String key = achievementKeyBuilder.userProgress(achievementCode.getName(), userId);
+        return redisCounterTemplate.opsForValue().increment(key, 1);
+    }
+
+    public void decrementCounter(AchievementCode achievementCode, long userId, long delta) {
+        log.info("Decrement counter title: {}, userId = {}", achievementCode.getName(), userId);
+        String key = achievementKeyBuilder.userProgress(achievementCode.getName(), userId);
+        redisCounterTemplate.opsForValue().decrement(key, delta);
+    }
+
+    public void assignAchievement(AchievementCode achievementCode, long userId) {
+        log.info("Updating a cache with a completed achievement for a user, title: {}, userId = {}", achievementCode.getName(), userId);
+        String key = achievementKeyBuilder.assignAchievement(userId);
+        stringRedisTemplate.opsForSet().add(key, achievementCode.getName());
+        removeAchievementProgressTracking(achievementCode, userId);
+    }
+
+    public void removeAchievementProgressTracking(AchievementCode achievementCode, long userId) {
+        log.info("Removing tracking of the achievement to a user, title: {}, userId = {}", achievementCode.getName(), userId);
+        String key = achievementKeyBuilder.userProgress(achievementCode.getName(), userId);
+        stringRedisTemplate.delete(key);
+    }
+
+    public Boolean checkIfAchievementAssigned(AchievementCode achievementCode, long userId) {
+        log.info("Checking if an achievement has been assigned to a user, title: {}, userId = {}",
+                achievementCode.getName(), userId);
+        String key = achievementKeyBuilder.assignAchievement(userId);
+        Boolean isAssigned = stringRedisTemplate.opsForSet().isMember(key, achievementCode.getName());
+        if (isAssigned != null) {
+            log.info("Has the achievement been assigned: {}", isAssigned);
+            return isAssigned;
+        }
+        return false;
+    }
+}

--- a/src/main/java/faang/school/achievement/redis/RedisCounterServiceImpl.java
+++ b/src/main/java/faang/school/achievement/redis/RedisCounterServiceImpl.java
@@ -1,0 +1,11 @@
+package faang.school.achievement.redis;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RedisCounterServiceImpl extends RedisCounterService {
+    public RedisCounterServiceImpl(RedisTemplate<String, Long> redisCounterTemplate, RedisTemplate<String, String> stringRedisTemplate, AchievementKeyBuilder achievementKeyBuilder) {
+        super(redisCounterTemplate, stringRedisTemplate, achievementKeyBuilder);
+    }
+}

--- a/src/main/java/faang/school/achievement/redis/StartupCacheLoader.java
+++ b/src/main/java/faang/school/achievement/redis/StartupCacheLoader.java
@@ -1,0 +1,17 @@
+package faang.school.achievement.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StartupCacheLoader implements ApplicationListener<ContextRefreshedEvent> {
+    private final AchievementCache achievementCache;
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        achievementCache.init();
+    }
+}

--- a/src/main/java/faang/school/achievement/repository/AchievementProgressRepository.java
+++ b/src/main/java/faang/school/achievement/repository/AchievementProgressRepository.java
@@ -13,17 +13,17 @@ import java.util.Optional;
 public interface AchievementProgressRepository extends CrudRepository<AchievementProgress, Long> {
 
     @Query(value = """
-            SELECT ap
-            FROM AchievementProgress ap
-            WHERE ap.userId = :userId AND ap.achievement.id = :achievementId
-    """)
+                    SELECT ap
+                    FROM AchievementProgress ap
+                    WHERE ap.userId = :userId AND ap.achievement.id = :achievementId
+            """)
     Optional<AchievementProgress> findByUserIdAndAchievementId(long userId, long achievementId);
 
     @Query(nativeQuery = true, value = """
-            INSERT INTO user_achievement_progress (user_id, achievement_id, current_points)
-            VALUES (:userId, :achievementId, 0)
-            ON CONFLICT DO NOTHING
-    """)
+                    INSERT INTO user_achievement_progress (user_id, achievement_id, current_points)
+                    VALUES (:userId, :achievementId, 0)
+                    ON CONFLICT DO NOTHING
+            """)
     @Modifying
     void createProgressIfNecessary(long userId, long achievementId);
 

--- a/src/main/java/faang/school/achievement/repository/AchievementRepository.java
+++ b/src/main/java/faang/school/achievement/repository/AchievementRepository.java
@@ -1,9 +1,27 @@
 package faang.school.achievement.repository;
 
 import faang.school.achievement.model.Achievement;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface AchievementRepository extends CrudRepository<Achievement, Long> {
+    Optional<Achievement> findByTitle(String title);
+
+    @Query("SELECT a.points FROM Achievement a WHERE a.title = :title")
+    Long findPointsByTitle(String title);
+
+    @Query("SELECT a FROM Achievement a")
+    @EntityGraph(value = "achievement.userAchievements", type = EntityGraph.EntityGraphType.LOAD)
+    List<Achievement> findAllWithUserAchievements();
+
+    @Query("SELECT a FROM Achievement a WHERE a.id in :ids")
+    @EntityGraph(value = "achievement.progresses", type = EntityGraph.EntityGraphType.LOAD)
+    List<Achievement> findAllWithProgresses(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/faang/school/achievement/repository/UserAchievementRepository.java
+++ b/src/main/java/faang/school/achievement/repository/UserAchievementRepository.java
@@ -11,10 +11,10 @@ import java.util.List;
 public interface UserAchievementRepository extends CrudRepository<UserAchievement, Long> {
 
     @Query(value = """
-            SELECT CASE WHEN COUNT(ua) > 0 THEN true ELSE false END
-            FROM UserAchievement ua
-            WHERE ua.userId = :userId AND ua.achievement.id = :achievementId
-    """)
+                    SELECT CASE WHEN COUNT(ua) > 0 THEN true ELSE false END
+                    FROM UserAchievement ua
+                    WHERE ua.userId = :userId AND ua.achievement.id = :achievementId
+            """)
     boolean existsByUserIdAndAchievementId(long userId, long achievementId);
 
     List<UserAchievement> findByUserId(long userId);

--- a/src/main/java/faang/school/achievement/service/AchievementService.java
+++ b/src/main/java/faang/school/achievement/service/AchievementService.java
@@ -1,0 +1,73 @@
+package faang.school.achievement.service;
+
+import faang.school.achievement.dto.AchievementProgressRecord;
+import faang.school.achievement.mapper.AchievementMapper;
+import faang.school.achievement.model.Achievement;
+import faang.school.achievement.model.AchievementCode;
+import faang.school.achievement.model.AchievementProgress;
+import faang.school.achievement.redis.AchievementCache;
+import faang.school.achievement.repository.AchievementProgressRepository;
+import faang.school.achievement.repository.AchievementRepository;
+import faang.school.achievement.repository.UserAchievementRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AchievementService {
+    private final AchievementRepository achievementRepository;
+    private final AchievementProgressRepository achievementProgressRepository;
+    private final UserAchievementRepository userAchievementRepository;
+    private final AchievementMapper achievementMapper;
+    private final AchievementCache achievementCache;
+
+    @Transactional
+    public AchievementProgress saveAchievementProgress(AchievementProgressRecord progressRecord) {
+        log.info("Calling saveAchievementProgress, record: {}", progressRecord.achievement().getTitle());
+        Optional<AchievementProgress> loadedAchievementProgress =
+                achievementProgressRepository.findByUserIdAndAchievementId(progressRecord.userId(),
+                        progressRecord.achievement().getId());
+        AchievementProgress progress;
+        if (loadedAchievementProgress.isPresent()) {
+            progress = loadedAchievementProgress.get();
+            long currentPoints = progress.getCurrentPoints();
+            progress.setCurrentPoints(currentPoints + progressRecord.currentPoints());
+        } else {
+            AchievementProgress achievementProgress = achievementMapper.toAchievement(progressRecord);
+            progress = achievementProgressRepository.save(achievementProgress);
+        }
+        return progress;
+    }
+
+    @Transactional
+    public boolean assignAchievementIfCompleted(AchievementProgressRecord achievementProgressRecord) {
+        log.info("Assigning an achievement if completed, achievement progress record: {}",
+                achievementProgressRecord.achievement().getTitle());
+        long currentPoints = achievementProgressRecord.currentPoints();
+        Long achievementPoints = achievementRepository.findPointsByTitle(achievementProgressRecord.achievement().getTitle());
+        if (currentPoints >= achievementPoints) {
+            assignUserAchievement(achievementProgressRecord);
+            return true;
+        }
+        return false;
+    }
+
+    private void assignUserAchievement(AchievementProgressRecord achievementProgressRecord) {
+        log.info("Assigning a completed achievement to a user");
+        userAchievementRepository.save(achievementMapper.toUserAchievement(achievementProgressRecord));
+    }
+
+    public List<Achievement> getAchievements() {
+        return achievementCache.getAchievements();
+    }
+
+    public Achievement getAchievementByCode(AchievementCode achievementCode) {
+        return achievementCache.getAchievementByCode(achievementCode);
+    }
+}

--- a/src/main/java/faang/school/achievement/service/handlers/achievements/AchievementCacheSettings.java
+++ b/src/main/java/faang/school/achievement/service/handlers/achievements/AchievementCacheSettings.java
@@ -1,0 +1,6 @@
+package faang.school.achievement.service.handlers.achievements;
+
+import faang.school.achievement.model.AchievementCode;
+
+public record AchievementCacheSettings(AchievementCode achievementCode, Long counterThreshold) {
+}

--- a/src/main/java/faang/school/achievement/service/handlers/achievements/CollectorAchievementHandler.java
+++ b/src/main/java/faang/school/achievement/service/handlers/achievements/CollectorAchievementHandler.java
@@ -1,0 +1,29 @@
+package faang.school.achievement.service.handlers.achievements;
+
+import faang.school.achievement.kafka.events.Event;
+import faang.school.achievement.model.AchievementCode;
+import faang.school.achievement.redis.RedisCounterService;
+import faang.school.achievement.service.AchievementService;
+import faang.school.achievement.service.handlers.events.GoalCompletedEventHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CollectorAchievementHandler extends GoalCompletedEventHandler {
+    @Value("${achievements.collector.redis-counter-threshold}")
+    private Long counterThreshold;
+
+    public CollectorAchievementHandler(AchievementService achievementService, RedisCounterService cacheService) {
+        super(achievementService, cacheService);
+    }
+
+    @Override
+    public void handle(Event event) {
+        super.handleSingleCounterCache(event, new AchievementCacheSettings(getCode(), counterThreshold));
+    }
+
+    @Override
+    public AchievementCode getCode() {
+        return AchievementCode.COLLECTOR;
+    }
+}

--- a/src/main/java/faang/school/achievement/service/handlers/achievements/ExpertAchievementHandler.java
+++ b/src/main/java/faang/school/achievement/service/handlers/achievements/ExpertAchievementHandler.java
@@ -1,0 +1,29 @@
+package faang.school.achievement.service.handlers.achievements;
+
+import faang.school.achievement.kafka.events.Event;
+import faang.school.achievement.model.AchievementCode;
+import faang.school.achievement.redis.RedisCounterService;
+import faang.school.achievement.service.AchievementService;
+import faang.school.achievement.service.handlers.events.CommentAddedEventHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ExpertAchievementHandler extends CommentAddedEventHandler {
+    @Value("${achievements.expert.redis-counter-threshold}")
+    private Long counterThreshold;
+
+    public ExpertAchievementHandler(AchievementService achievementService, RedisCounterService cacheService) {
+        super(achievementService, cacheService);
+    }
+
+    @Override
+    public void handle(Event event) {
+        super.handleSingleCounterCache(event, new AchievementCacheSettings(getCode(), counterThreshold));
+    }
+
+    @Override
+    public AchievementCode getCode() {
+        return AchievementCode.EXPERT;
+    }
+}

--- a/src/main/java/faang/school/achievement/service/handlers/events/AbstractEventHandler.java
+++ b/src/main/java/faang/school/achievement/service/handlers/events/AbstractEventHandler.java
@@ -1,0 +1,53 @@
+package faang.school.achievement.service.handlers.events;
+
+import faang.school.achievement.dto.AchievementProgressRecord;
+import faang.school.achievement.exceptions.ObjectAlreadyExistsException;
+import faang.school.achievement.kafka.events.Event;
+import faang.school.achievement.model.Achievement;
+import faang.school.achievement.model.AchievementCode;
+import faang.school.achievement.model.AchievementProgress;
+import faang.school.achievement.redis.RedisCounterService;
+import faang.school.achievement.service.AchievementService;
+import faang.school.achievement.service.handlers.achievements.AchievementCacheSettings;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Objects;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class AbstractEventHandler implements EventHandler {
+    protected final AchievementService achievementService;
+    protected final RedisCounterService cacheService;
+
+    public void handleSingleCounterCache(Event event, AchievementCacheSettings cacheSettings) {
+        log.info("Handling single counter cache event: {}", event);
+        long userId = event.getUserId();
+        AchievementCode achievementCode = cacheSettings.achievementCode();
+        Long counterThreshold = cacheSettings.counterThreshold();
+
+        Boolean isAchievementAlreadyAssigned = cacheService.checkIfAchievementAssigned(achievementCode, userId);
+        if (!isAchievementAlreadyAssigned) {
+            Long counter = cacheService.incrementCounter(achievementCode, userId);
+            if (Objects.equals(counter, counterThreshold)) {
+                Achievement achievement = achievementService.getAchievementByCode(achievementCode);
+                AchievementProgress achievementProgress;
+                try {
+                    achievementProgress = achievementService.saveAchievementProgress(new AchievementProgressRecord(
+                            achievement, userId, counter));
+                } catch (ObjectAlreadyExistsException e) {
+                    return;
+                }
+                boolean isAchievementCompleted = achievementService.assignAchievementIfCompleted(
+                        new AchievementProgressRecord(achievementProgress.getAchievement(),
+                                achievementProgress.getUserId(),
+                                achievementProgress.getCurrentPoints()));
+                if (isAchievementCompleted) {
+                    cacheService.assignAchievement(achievementCode, userId);
+                } else {
+                    cacheService.decrementCounter(achievementCode, userId, achievementProgress.getCurrentPoints());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/faang/school/achievement/service/handlers/events/CommentAddedEventHandler.java
+++ b/src/main/java/faang/school/achievement/service/handlers/events/CommentAddedEventHandler.java
@@ -1,0 +1,22 @@
+package faang.school.achievement.service.handlers.events;
+
+import faang.school.achievement.kafka.events.CommentAddedEvent;
+import faang.school.achievement.kafka.events.Event;
+import faang.school.achievement.redis.RedisCounterService;
+import faang.school.achievement.service.AchievementService;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public abstract class CommentAddedEventHandler extends AbstractEventHandler {
+
+    public CommentAddedEventHandler(AchievementService achievementService, RedisCounterService cacheService) {
+        super(achievementService, cacheService);
+    }
+
+    @Override
+    public List<Class<? extends Event>> getEventTypes() {
+        return List.of(CommentAddedEvent.class);
+    }
+}

--- a/src/main/java/faang/school/achievement/service/handlers/events/EventHandler.java
+++ b/src/main/java/faang/school/achievement/service/handlers/events/EventHandler.java
@@ -1,0 +1,14 @@
+package faang.school.achievement.service.handlers.events;
+
+import faang.school.achievement.kafka.events.Event;
+import faang.school.achievement.model.AchievementCode;
+
+import java.util.List;
+
+public interface EventHandler {
+    void handle(Event event);
+
+    AchievementCode getCode();
+
+    List<Class<? extends Event>> getEventTypes();
+}

--- a/src/main/java/faang/school/achievement/service/handlers/events/GoalCompletedEventHandler.java
+++ b/src/main/java/faang/school/achievement/service/handlers/events/GoalCompletedEventHandler.java
@@ -1,0 +1,19 @@
+package faang.school.achievement.service.handlers.events;
+
+import faang.school.achievement.kafka.events.Event;
+import faang.school.achievement.kafka.events.GoalCompletedEvent;
+import faang.school.achievement.redis.RedisCounterService;
+import faang.school.achievement.service.AchievementService;
+
+import java.util.List;
+
+public abstract class GoalCompletedEventHandler extends AbstractEventHandler {
+    public GoalCompletedEventHandler(AchievementService achievementService, RedisCounterService cacheService) {
+        super(achievementService, cacheService);
+    }
+
+    @Override
+    public List<Class<? extends Event>> getEventTypes() {
+        return List.of(GoalCompletedEvent.class);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,6 +38,97 @@ spring:
       channel:
         achievement: achievement_channel
         follower: follower_channel
+      achievements:
+        ttl-s: 300
+
+  kafka:
+    bootstrap-servers: localhost:9092, localhost:9094
+    consumers:
+      comment-added:
+        name: comment-added
+        group-id: comment-group
+        ack-mode: MANUAL_IMMEDIATE
+        concurrency: 1
+        max-poll-records: 100
+        offset-reset-config: latest
+
+      goal-completed:
+        name: goal-completed
+        group-id: goal-group
+        concurrency: 1
+        ack-mode: MANUAL_IMMEDIATE
+        max-poll-records: 50
+        offset-reset-config: latest
+    topics:
+      goal-completed:
+        name: goal-completed-event-topic
+      comment-added:
+        name: comment-added-event-topic
+
+achievements:
+  collector:
+    title: COLLECTOR
+    description: For 100 goals
+    rarity: 3
+    points: 15
+    ttl-s: 300
+    redis-counter-threshold: 2
+
+  mr-productivity:
+    title: MR PRODUCTIVITY
+    description: For 1000 finished tasks
+    rarity: 4
+    points: 20
+    ttl-s: 300
+    redis-counter-threshold: 3
+
+  expert:
+    title: EXPERT
+    description: For 1000 comments
+    rarity: 1
+    points: 5
+    ttl-s: 300
+    redis-counter-threshold: 3
+
+  sensei:
+    title: SENSEI
+    description: For 30 mentees
+    rarity: 4
+    points: 20
+    ttl-s: 300
+    redis-counter-threshold: 3
+
+  manager:
+    title: MANAGER
+    description: For 10 teams
+    rarity: 2
+    points: 10
+    ttl-s: 300
+    redis-counter-threshold: 3
+
+  celebrity:
+    title: CELEBRITY
+    description: For 1 000 000 subscribers
+    rarity: 4
+    points: 20
+    ttl-s: 300
+    redis-counter-threshold: 3
+
+  writer:
+    title: WRITER
+    description: For 100 posts published
+    rarity: 2
+    points: 10
+    ttl-s: 300
+    redis-counter-threshold: 3
+
+  handsome:
+    title: HANDSOME
+    description: For uploaded profile photo
+    rarity: 0
+    points: 2
+    ttl-s: 300
+    redis-counter-threshold: 3
 
 server:
   port: 8085

--- a/src/main/resources/db/changelog/changeset/achievement_V001__initial.sql
+++ b/src/main/resources/db/changelog/changeset/achievement_V001__initial.sql
@@ -29,7 +29,8 @@ CREATE TABLE user_achievement_progress (
     created_at timestamptz DEFAULT current_timestamp,
     updated_at timestamptz DEFAULT current_timestamp,
 
-    CONSTRAINT fk_user_achievement_progress_id FOREIGN KEY (user_id) REFERENCES users (id)
+    CONSTRAINT fk_user_achievement_progress_id FOREIGN KEY (user_id) REFERENCES users (id),
+    CONSTRAINT fk_achievement_achievement_progress_id FOREIGN KEY (achievement_id) REFERENCES achievement (id)
 );
 
 CREATE UNIQUE INDEX user_achievement_progress_idx ON user_achievement_progress (user_id, achievement_id);

--- a/src/test/java/faang/school/achievement/service/AchievementServiceTest.java
+++ b/src/test/java/faang/school/achievement/service/AchievementServiceTest.java
@@ -1,0 +1,138 @@
+package faang.school.achievement.service;
+
+import faang.school.achievement.dto.AchievementProgressRecord;
+import faang.school.achievement.mapper.AchievementMapper;
+import faang.school.achievement.model.Achievement;
+import faang.school.achievement.model.AchievementCode;
+import faang.school.achievement.model.AchievementProgress;
+import faang.school.achievement.redis.AchievementCache;
+import faang.school.achievement.repository.AchievementProgressRepository;
+import faang.school.achievement.repository.AchievementRepository;
+import faang.school.achievement.repository.UserAchievementRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AchievementServiceTest {
+    @InjectMocks
+    private AchievementService achievementService;
+
+    @Mock
+    private AchievementRepository achievementRepository;
+    @Mock
+    private AchievementProgressRepository achievementProgressRepository;
+    @Mock
+    private UserAchievementRepository userAchievementRepository;
+    @Mock
+    private AchievementMapper achievementMapper;
+    @Mock
+    private AchievementCache achievementCache;
+
+    @Test
+    void saveAchievementProgress_shouldUpdateExistingProgress() {
+        Achievement achievement = new Achievement();
+        achievement.setId(1L);
+        achievement.setTitle("Java Master");
+
+        AchievementProgressRecord record = new AchievementProgressRecord(achievement, 1L, 10L);
+
+        AchievementProgress existingProgress = new AchievementProgress();
+        existingProgress.setCurrentPoints(5L);
+
+        when(achievementProgressRepository.findByUserIdAndAchievementId(1L, 1L))
+                .thenReturn(Optional.of(existingProgress));
+
+        AchievementProgress result = achievementService.saveAchievementProgress(record);
+
+        assertEquals(15L, result.getCurrentPoints());
+        verify(achievementProgressRepository, never()).save(any());
+    }
+
+    @Test
+    void saveAchievementProgress_shouldCreateNewProgress() {
+        Achievement achievement = new Achievement();
+        achievement.setId(2L);
+        achievement.setTitle("Newbie");
+
+        AchievementProgressRecord record = new AchievementProgressRecord(achievement, 2L, 20L);
+
+        when(achievementProgressRepository.findByUserIdAndAchievementId(2L, 2L))
+                .thenReturn(Optional.empty());
+
+        AchievementProgress mappedProgress = new AchievementProgress();
+        mappedProgress.setCurrentPoints(20L);
+        when(achievementMapper.toAchievement(record)).thenReturn(mappedProgress);
+        when(achievementProgressRepository.save(mappedProgress)).thenReturn(mappedProgress);
+
+        AchievementProgress result = achievementService.saveAchievementProgress(record);
+
+        assertEquals(20L, result.getCurrentPoints());
+        verify(achievementProgressRepository).save(mappedProgress);
+    }
+
+    @Test
+    void assignAchievementIfCompleted_shouldAssignIfCompleted() {
+        Achievement achievement = new Achievement();
+        achievement.setTitle("Code Guru");
+
+        AchievementProgressRecord record = new AchievementProgressRecord(achievement, 3L, 100L);
+
+        when(achievementRepository.findPointsByTitle("Code Guru")).thenReturn(50L);
+
+        when(achievementMapper.toUserAchievement(record)).thenReturn(any());
+        boolean result = achievementService.assignAchievementIfCompleted(record);
+
+        assertTrue(result);
+        verify(userAchievementRepository).save(any());
+    }
+
+    @Test
+    void assignAchievementIfCompleted_shouldNotAssignIfNotCompleted() {
+        Achievement achievement = new Achievement();
+        achievement.setTitle("Code Novice");
+
+        AchievementProgressRecord record = new AchievementProgressRecord(achievement, 4L, 30L);
+
+        when(achievementRepository.findPointsByTitle("Code Novice")).thenReturn(100L);
+
+        boolean result = achievementService.assignAchievementIfCompleted(record);
+
+        Assertions.assertFalse(result);
+        verify(userAchievementRepository, never()).save(any());
+    }
+
+    @Test
+    void getAchievements_shouldReturnAchievementsFromCache() {
+        List<Achievement> achievements = List.of(new Achievement(), new Achievement());
+
+        when(achievementCache.getAchievements()).thenReturn(achievements);
+
+        List<Achievement> result = achievementService.getAchievements();
+
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void getAchievementByCode_shouldReturnFromCache() {
+        AchievementCode code = AchievementCode.EXPERT;
+        Achievement achievement = new Achievement();
+
+        when(achievementCache.getAchievementByCode(code)).thenReturn(achievement);
+
+        Achievement result = achievementService.getAchievementByCode(code);
+
+        assertEquals(achievement, result);
+    }
+}


### PR DESCRIPTION
Добавить настройку Kafka Consumer.
Реализовать обработку ивентов из Кафка при помощи промежуточного кеширования в Redis и последующего сохранения данных в postgreSQL.
Реализовать кеширование достижений с прогревом кеша.

Задача: https://faang-school.atlassian.net/jira/software/c/projects/BJS2/boards/487?selectedIssue=BJS2-77561
Но большинство реализации сделано вне данной задачи.

Пакеты с реализацией:
config/kafka
config/redis
./kafka
./redis
service/handlers