### PR TITLE
feature-BJS2-96931-achievement-caching

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/src/main/java/faang/school/achievement/cache/AchievementCache.java
+++ b/src/main/java/faang/school/achievement/cache/AchievementCache.java
@@ -4,8 +4,12 @@ import faang.school.achievement.model.Achievement;
 import faang.school.achievement.repository.AchievementRepository;
 import faang.school.achievement.source.ReloadableAchievementSource;
 import jakarta.annotation.PostConstruct;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
 import java.util.Map;
@@ -16,6 +20,8 @@ import java.util.stream.StreamSupport;
 
 @RequiredArgsConstructor
 @Component("AchievementCache")
+@Validated
+@Slf4j
 public class AchievementCache implements ReloadableAchievementSource {
     private final AchievementRepository achievementRepository;
     private Map<String, Achievement> achievementCacheByTitle;
@@ -27,12 +33,14 @@ public class AchievementCache implements ReloadableAchievementSource {
     }
 
     @Override
-    public Optional<Achievement> getByTitle(String title) {
+    public Optional<Achievement> getByTitle(@NotBlank String title) {
+        log.debug("Achievement with title = {} taken from the cache", title);
         return Optional.ofNullable(achievementCacheByTitle.get(title));
     }
 
     @Override
     public List<Achievement> getAll() {
+        log.debug("All achievements are taken from the cache");
         return achievementCacheByTitle
                 .values()
                 .stream()
@@ -57,8 +65,8 @@ public class AchievementCache implements ReloadableAchievementSource {
     }
 
     @Override
-    public Optional<Achievement> getById(long id) {
-        System.out.print("Взят из кеша");
+    public Optional<Achievement> getById(@Positive long id) {
+        log.debug("Achievement with id = {} taken from the cache", id);
         return Optional.ofNullable(achievementCacheById.get(id));
     }
 }

--- a/src/main/java/faang/school/achievement/cache/AchievementCache.java
+++ b/src/main/java/faang/school/achievement/cache/AchievementCache.java
@@ -1,0 +1,64 @@
+package faang.school.achievement.cache;
+
+import faang.school.achievement.model.Achievement;
+import faang.school.achievement.repository.AchievementRepository;
+import faang.school.achievement.source.ReloadableAchievementSource;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+@RequiredArgsConstructor
+@Component("AchievementCache")
+public class AchievementCache implements ReloadableAchievementSource {
+    private final AchievementRepository achievementRepository;
+    private Map<String, Achievement> achievementCacheByTitle;
+    private Map<Long, Achievement> achievementCacheById;
+
+    @PostConstruct
+    private void initCache() {
+        reloadCache();
+    }
+
+    @Override
+    public Optional<Achievement> getByTitle(String title) {
+        return Optional.ofNullable(achievementCacheByTitle.get(title));
+    }
+
+    @Override
+    public List<Achievement> getAll() {
+        return achievementCacheByTitle
+                .values()
+                .stream()
+                .toList();
+    }
+
+    @Override
+    public void reloadCache() {
+        Stream<Achievement> achievements = StreamSupport.stream(achievementRepository.findAll().spliterator(), false);
+
+        achievementCacheByTitle = achievements
+                .collect(Collectors.toMap(
+                        Achievement::getTitle,
+                        achievement -> achievement
+                ));
+
+        achievementCacheById = achievementCacheByTitle.values().stream()
+                .collect(Collectors.toMap(
+                        Achievement::getId,
+                        achievement -> achievement
+                ));
+    }
+
+    @Override
+    public Optional<Achievement> getById(long id) {
+        System.out.print("Взят из кеша");
+        return Optional.ofNullable(achievementCacheById.get(id));
+    }
+}

--- a/src/main/java/faang/school/achievement/controller/AchievementController.java
+++ b/src/main/java/faang/school/achievement/controller/AchievementController.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class AchievementController {
     private final AchievementServiceImpl achievementService;
 
-    @PostMapping
+    @PostMapping("/achievements")
     public List<AchievementResponseDto> getAllAchievements(@RequestBody AchievementFilterDto filterDto) {
         return achievementService.getAllAchievements(filterDto);
     }

--- a/src/main/java/faang/school/achievement/repository/AchievementRepository.java
+++ b/src/main/java/faang/school/achievement/repository/AchievementRepository.java
@@ -1,9 +1,15 @@
 package faang.school.achievement.repository;
 
 import faang.school.achievement.model.Achievement;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface AchievementRepository extends CrudRepository<Achievement, Long> {
+    @Query("SELECT a FROM Achievement a WHERE a.title = :title")
+    Optional<Achievement> findByTitle(@Param("title") String title);
 }

--- a/src/main/java/faang/school/achievement/service/AchievementServiceImpl.java
+++ b/src/main/java/faang/school/achievement/service/AchievementServiceImpl.java
@@ -12,30 +12,32 @@ import faang.school.achievement.model.AchievementProgress;
 import faang.school.achievement.model.UserAchievement;
 import faang.school.achievement.model.UserAchievementStatus;
 import faang.school.achievement.repository.AchievementProgressRepository;
-import faang.school.achievement.repository.AchievementRepository;
 import faang.school.achievement.repository.UserAchievementRepository;
+import faang.school.achievement.source.AchievementSource;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static faang.school.achievement.utils.Utils.stringFormatting;
 
-@Component
+@Slf4j
+@Service
 @RequiredArgsConstructor
 @Validated
 public class AchievementServiceImpl implements AchievementService {
     private static final long ZERO_VALUE = 0L;
-    private final AchievementRepository achievementRepository;
+    @Qualifier("AchievementCache")
+    private final AchievementSource achievementSource;
     private final AchievementProgressRepository achievementProgressRepository;
     private final UserAchievementRepository userAchievementRepository;
     private final AchievementMapper achievementMapper;
@@ -62,7 +64,7 @@ public class AchievementServiceImpl implements AchievementService {
 
     @Override
     public List<AchievementResponseDto> getAllAchievements(AchievementFilterDto filterDto) {
-        Stream<Achievement> achievements = StreamSupport.stream(achievementRepository.findAll().spliterator(), false);
+        Stream<Achievement> achievements = achievementSource.getAll().stream();
 
         for (AchievementFilter achievementFilter : achievementFilters) {
             if (achievementFilter.isApplicable(filterDto)) {
@@ -79,12 +81,11 @@ public class AchievementServiceImpl implements AchievementService {
      */
     @Override
     public AchievementResponseDto getAchievementsById(@Positive long achievementsId) {
-        Optional<Achievement> achievementFound = achievementRepository.findById(achievementsId);
-        if (achievementFound.isEmpty()) {
-            throw new EntityNotFoundException(stringFormatting("Achievement Id {} not found", achievementsId));
-        }
-        Achievement userAchievement = achievementFound.get();
-        return achievementMapper.toAchievementResponseDto(userAchievement);
+        Achievement achievementFound = achievementSource.getById(achievementsId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        stringFormatting("Achievement Id {} not found", achievementsId)
+                ));
+        return achievementMapper.toAchievementResponseDto(achievementFound);
     }
 
     /**

--- a/src/main/java/faang/school/achievement/source/AchievementSource.java
+++ b/src/main/java/faang/school/achievement/source/AchievementSource.java
@@ -1,0 +1,14 @@
+package faang.school.achievement.source;
+
+import faang.school.achievement.model.Achievement;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AchievementSource {
+    List<Achievement> getAll();
+
+    Optional<Achievement> getByTitle(String title);
+
+    Optional<Achievement> getById(long id);
+}

--- a/src/main/java/faang/school/achievement/source/DbAchievementSource.java
+++ b/src/main/java/faang/school/achievement/source/DbAchievementSource.java
@@ -2,8 +2,12 @@ package faang.school.achievement.source;
 
 import faang.school.achievement.model.Achievement;
 import faang.school.achievement.repository.AchievementRepository;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,16 +15,20 @@ import java.util.stream.StreamSupport;
 
 @RequiredArgsConstructor
 @Component("DbAchievementSource")
+@Validated
+@Slf4j
 public class DbAchievementSource implements AchievementSource {
     private final AchievementRepository achievementRepository;
 
     @Override
     public List<Achievement> getAll() {
+        log.debug("All achievements are taken from the database");
         return StreamSupport.stream(achievementRepository.findAll().spliterator(), false).toList();
     }
 
     @Override
-    public Optional<Achievement> getByTitle(String title) {
+    public Optional<Achievement> getByTitle(@NotBlank String title) {
+        log.debug("Achievement with title = {} taken from the database", title);
         Optional<Achievement> result = Optional.empty();
         List<Achievement> allAchievement = getAll();
         for (Achievement achievement : allAchievement) {
@@ -33,7 +41,8 @@ public class DbAchievementSource implements AchievementSource {
     }
 
     @Override
-    public Optional<Achievement> getById(long id) {
+    public Optional<Achievement> getById(@Positive long id) {
+        log.debug("Achievement with id = {} taken from the database", id);
         return achievementRepository.findById(id);
     }
 }

--- a/src/main/java/faang/school/achievement/source/DbAchievementSource.java
+++ b/src/main/java/faang/school/achievement/source/DbAchievementSource.java
@@ -29,15 +29,7 @@ public class DbAchievementSource implements AchievementSource {
     @Override
     public Optional<Achievement> getByTitle(@NotBlank String title) {
         log.debug("Achievement with title = {} taken from the database", title);
-        Optional<Achievement> result = Optional.empty();
-        List<Achievement> allAchievement = getAll();
-        for (Achievement achievement : allAchievement) {
-            if (achievement.getTitle().equals(title)) {
-                result = Optional.of(achievement);
-                break;
-            }
-        }
-        return result;
+        return achievementRepository.findByTitle(title);
     }
 
     @Override

--- a/src/main/java/faang/school/achievement/source/DbAchievementSource.java
+++ b/src/main/java/faang/school/achievement/source/DbAchievementSource.java
@@ -1,0 +1,39 @@
+package faang.school.achievement.source;
+
+import faang.school.achievement.model.Achievement;
+import faang.school.achievement.repository.AchievementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+@RequiredArgsConstructor
+@Component("DbAchievementSource")
+public class DbAchievementSource implements AchievementSource {
+    private final AchievementRepository achievementRepository;
+
+    @Override
+    public List<Achievement> getAll() {
+        return StreamSupport.stream(achievementRepository.findAll().spliterator(), false).toList();
+    }
+
+    @Override
+    public Optional<Achievement> getByTitle(String title) {
+        Optional<Achievement> result = Optional.empty();
+        List<Achievement> allAchievement = getAll();
+        for (Achievement achievement : allAchievement) {
+            if (achievement.getTitle().equals(title)) {
+                result = Optional.of(achievement);
+                break;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public Optional<Achievement> getById(long id) {
+        return achievementRepository.findById(id);
+    }
+}

--- a/src/main/java/faang/school/achievement/source/ReloadableAchievementSource.java
+++ b/src/main/java/faang/school/achievement/source/ReloadableAchievementSource.java
@@ -1,0 +1,5 @@
+package faang.school.achievement.source;
+
+public interface ReloadableAchievementSource extends AchievementSource {
+    void reloadCache();
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/postgres
+    url: jdbc:postgresql://78.36.7.9:5432/postgres
     username: user
     password: password
   jpa:
@@ -41,4 +41,3 @@ payment-service:
 user-service:
   host: localhost
   port: 8080
-

--- a/src/test/java/faang/school/achievement/cache/AchievementCacheTest.java
+++ b/src/test/java/faang/school/achievement/cache/AchievementCacheTest.java
@@ -1,0 +1,136 @@
+package faang.school.achievement.cache;
+
+import faang.school.achievement.model.Achievement;
+import faang.school.achievement.repository.AchievementRepository;
+import faang.school.achievement.service.DataForTests;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AchievementCacheTest extends DataForTests {
+    @Mock
+    private AchievementRepository achievementRepository;
+    @InjectMocks
+    private AchievementCache achievementCache;
+
+    @BeforeEach
+    void setUp() {
+        when(achievementRepository.findAll()).thenReturn(allAchievements);
+        achievementCache.reloadCache();
+    }
+
+    @Test
+    void getByTitle_shouldReturnAchievementWhenExists() {
+        Optional<Achievement> result = achievementCache.getByTitle(ACHIEVEMENT_TITLE_COLLECTOR);
+
+        assertTrue(result.isPresent());
+        assertEquals(ACHIEVEMENT_ID_1, result.get().getId());
+        assertEquals(ACHIEVEMENT_TITLE_COLLECTOR, result.get().getTitle());
+    }
+
+    @Test
+    void getByTitle_shouldReturnEmptyWhenNotExists() {
+        Optional<Achievement> result = achievementCache.getByTitle("Non Existent");
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void getById_shouldReturnAchievementWhenExists() {
+        Optional<Achievement> result = achievementCache.getById(ACHIEVEMENT_ID_1);
+
+        assertTrue(result.isPresent());
+        assertEquals(ACHIEVEMENT_ID_1, result.get().getId());
+        assertEquals(ACHIEVEMENT_TITLE_COLLECTOR, result.get().getTitle());
+    }
+
+    @Test
+    void getById_shouldReturnEmptyWhenNotExists() {
+        Optional<Achievement> result = achievementCache.getById(UNKNOWN_ID);
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void getAll_shouldReturnAllAchievements() {
+        List<Achievement> achievementActual = achievementCache.getAll();
+
+        assertNotNull(achievementActual);
+        assertEquals(8, achievementActual.size());
+        assertEquals(new HashSet<>(allAchievements),
+                new HashSet<>(achievementActual));
+    }
+
+    @Test
+    void reloadCache_shouldUpdateCacheWithNewData() {
+
+        when(achievementRepository.findAll()).thenReturn(allAchievements);
+        achievementCache.reloadCache();
+
+        List<Achievement> achievementActual = achievementCache.getAll();
+        assertEquals(8, achievementActual.size());
+        assertEquals(new HashSet<>(allAchievements),
+                new HashSet<>(achievementActual));
+    }
+
+    @Test
+    void reloadCache_shouldReplaceOldCache() {
+        Achievement newAchievement = Achievement.builder()
+                .id(10L)
+                .title(UNKNOWN_ACHIEVEMENT_TITLE)
+                .build();
+
+        when(achievementRepository.findAll()).thenReturn(List.of(newAchievement));
+        achievementCache.reloadCache();
+
+        List<Achievement> result = achievementCache.getAll();
+        assertEquals(1, result.size());
+        assertFalse(achievementCache.getByTitle(ACHIEVEMENT_TITLE_COLLECTOR).isPresent());
+        assertTrue(achievementCache.getByTitle(UNKNOWN_ACHIEVEMENT_TITLE).isPresent());
+    }
+
+    @Test
+    void reloadCache_shouldBeCalledOnce() {
+        verify(achievementRepository).findAll();
+    }
+
+    @Test
+    void getById_shouldNotQueryRepositoryAfterCacheInit() {
+        clearInvocations(achievementRepository);
+
+        achievementCache.getById(ACHIEVEMENT_ID_1);
+        achievementCache.getById(ACHIEVEMENT_ID_2);
+
+        verify(achievementRepository, never()).findAll();
+        verify(achievementRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    void testGetByTitle_shouldNotQueryRepositoryAfterCacheInit() {
+        clearInvocations(achievementRepository);
+
+        achievementCache.getByTitle(ACHIEVEMENT_TITLE_COLLECTOR);
+        achievementCache.getByTitle(ACHIEVEMENT_TITLE_EXPERT);
+
+        verify(achievementRepository, never()).findAll();
+    }
+}

--- a/src/test/java/faang/school/achievement/filters/TitleFilterTest.java
+++ b/src/test/java/faang/school/achievement/filters/TitleFilterTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TitleFilterTest extends DataForTests {
 
     private final AchievementFilter filter = new TitleFilter();
-    private final AchievementFilterDto achievementFilterDto = new AchievementFilterDto(TITLE,
+    private final AchievementFilterDto achievementFilterDto = new AchievementFilterDto(ACHIEVEMENT_TITLE_COLLECTOR,
             null,
             null);
 

--- a/src/test/java/faang/school/achievement/service/AchievementServiceImplTest.java
+++ b/src/test/java/faang/school/achievement/service/AchievementServiceImplTest.java
@@ -1,5 +1,6 @@
 package faang.school.achievement.service;
 
+import faang.school.achievement.cache.AchievementCache;
 import faang.school.achievement.dto.AchievementFilterDto;
 import faang.school.achievement.dto.AchievementProgressResponseDto;
 import faang.school.achievement.dto.AchievementResponseDto;
@@ -16,7 +17,6 @@ import faang.school.achievement.model.Rarity;
 import faang.school.achievement.model.UserAchievement;
 import faang.school.achievement.model.UserAchievementStatus;
 import faang.school.achievement.repository.AchievementProgressRepository;
-import faang.school.achievement.repository.AchievementRepository;
 import faang.school.achievement.repository.UserAchievementRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(MockitoExtension.class)
 public class AchievementServiceImplTest extends DataForTests {
@@ -55,7 +56,7 @@ public class AchievementServiceImplTest extends DataForTests {
     @Spy
     private AchievementMapper achievementMapper = Mappers.getMapper(AchievementMapper.class);
     @Mock
-    private AchievementRepository achievementRepository;
+    private AchievementCache achievementCache;
     @Mock
     private AchievementProgressRepository achievementProgressRepository;
     @Mock
@@ -77,7 +78,7 @@ public class AchievementServiceImplTest extends DataForTests {
                 titleAchievementFilter);
 
         achievementService = Mockito.spy(new AchievementServiceImpl(
-                achievementRepository,
+                achievementCache,
                 achievementProgressRepository,
                 userAchievementRepository,
                 achievementMapper,
@@ -170,7 +171,7 @@ public class AchievementServiceImplTest extends DataForTests {
             List<Achievement> achievements,
             String testDescription
     ) {
-        when(achievementRepository.findAll()).thenReturn(allAchievements);
+        when(achievementCache.getAll()).thenReturn(allAchievements);
 
         List<AchievementResponseDto> achievementsResponseDto = achievements.stream()
                 .map(achievementMapper::toAchievementResponseDto)
@@ -179,7 +180,7 @@ public class AchievementServiceImplTest extends DataForTests {
         List<AchievementResponseDto> resultFiltredAllAchievements = achievementService
                 .getAllAchievements(achievementFilterDto);
         assertEquals(new HashSet<>(resultFiltredAllAchievements), new HashSet<>(achievementsResponseDto));
-        verify(achievementRepository, times(1)).findAll();
+        verify(achievementCache, times(1)).getAll();
 
 
     }
@@ -211,7 +212,7 @@ public class AchievementServiceImplTest extends DataForTests {
         AchievementResponseDto achievementResponseDto = achievementMapper
                 .toAchievementResponseDto(achievementCollector);
 
-        when(achievementRepository.findById(ACHIEVEMENT_ID_1)).thenReturn(Optional.of(achievementCollector));
+        when(achievementCache.getById(ACHIEVEMENT_ID_1)).thenReturn(Optional.of(achievementCollector));
         AchievementResponseDto resultFiltredAllAchievements = achievementService
                 .getAchievementsById(ACHIEVEMENT_ID_1);
 
@@ -220,7 +221,7 @@ public class AchievementServiceImplTest extends DataForTests {
 
     @Test
     void getAchievementsById_achievementMissing() {
-        when(achievementRepository.findById(UNKNOWN_ID)).thenReturn(Optional.empty());
+        when(achievementCache.getById(UNKNOWN_ID)).thenReturn(Optional.empty());
 
         assertThrows(EntityNotFoundException.class,
                 () -> achievementService.getAchievementsById(UNKNOWN_ID));

--- a/src/test/java/faang/school/achievement/service/DataForTests.java
+++ b/src/test/java/faang/school/achievement/service/DataForTests.java
@@ -15,6 +15,7 @@ public abstract class DataForTests {
     protected static final long UNKNOWN_ID = Long.MAX_VALUE;
     protected static final long ACHIEVEMENT_ID_1 = 1L;
     protected static final long ACHIEVEMENT_ID_2 = 2L;
+    protected static final long ACHIEVEMENT_ID_3 = 3L;
 
     protected static final Long USER_ID_1 = 1L;
     protected static final String DESCRIPTION = "100";

--- a/src/test/java/faang/school/achievement/service/DataForTests.java
+++ b/src/test/java/faang/school/achievement/service/DataForTests.java
@@ -14,20 +14,23 @@ public abstract class DataForTests {
     protected static final long USER_ID_2 = 2L;
     protected static final long UNKNOWN_ID = Long.MAX_VALUE;
     protected static final long ACHIEVEMENT_ID_1 = 1L;
+    protected static final long ACHIEVEMENT_ID_2 = 2L;
+
     protected static final Long USER_ID_1 = 1L;
     protected static final String DESCRIPTION = "100";
-    protected static final String TITLE = "COLLECTOR";
-
+    protected static final String ACHIEVEMENT_TITLE_COLLECTOR = "COLLECTOR";
+    protected static final String ACHIEVEMENT_TITLE_EXPERT = "EXPERT";
+    protected static final String UNKNOWN_ACHIEVEMENT_TITLE = "ONLY ACHIEVEMENT";
 
     protected Achievement achievementCollector = Achievement.builder()
-            .id(1L)
+            .id(ACHIEVEMENT_ID_1)
             .title("COLLECTOR")
             .description("For 100 goals")
             .rarity(Rarity.EPIC)
             .points(15L)
             .build();
     protected Achievement achievementMrProductivity = Achievement.builder()
-            .id(2L)
+            .id(ACHIEVEMENT_ID_2)
             .title("MR PRODUCTIVITY")
             .description("For 1000 finished tasks")
             .rarity(Rarity.LEGENDARY)

--- a/src/test/java/faang/school/achievement/source/DbAchievementSourceTest.java
+++ b/src/test/java/faang/school/achievement/source/DbAchievementSourceTest.java
@@ -1,0 +1,144 @@
+package faang.school.achievement.source;
+
+import faang.school.achievement.model.Achievement;
+import faang.school.achievement.repository.AchievementRepository;
+import faang.school.achievement.service.DataForTests;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class DbAchievementSourceTest extends DataForTests {
+
+    @Mock
+    private AchievementRepository achievementRepository;
+
+    @InjectMocks
+    private DbAchievementSource dbAchievementSource;
+
+    @Test
+    void getAll_shouldReturnAllAchievements() {
+        when(achievementRepository.findAll()).thenReturn(allAchievements);
+
+        List<Achievement> achievementActual = dbAchievementSource.getAll();
+
+        assertNotNull(achievementActual);
+        assertEquals(8, achievementActual.size());
+        assertEquals(new HashSet<>(allAchievements),
+                new HashSet<>(achievementActual));
+        verify(achievementRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getAll_shouldReturnEmptyListWhenNoAchievements() {
+        when(achievementRepository.findAll()).thenReturn(Collections.emptyList());
+
+        List<Achievement> result = dbAchievementSource.getAll();
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(achievementRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getByTitle_shouldReturnAchievementWhenExists() {
+        when(achievementRepository.findAll()).thenReturn(allAchievements);
+
+        Optional<Achievement> result = dbAchievementSource.getByTitle(ACHIEVEMENT_TITLE_COLLECTOR);
+
+        assertTrue(result.isPresent());
+        assertEquals(ACHIEVEMENT_ID_1, result.get().getId());
+        assertEquals(ACHIEVEMENT_TITLE_COLLECTOR, result.get().getTitle());
+        verify(achievementRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getByTitle_shouldReturnEmptyWhenNotExists() {
+        when(achievementRepository.findAll()).thenReturn(allAchievements);
+
+        Optional<Achievement> result = dbAchievementSource.getByTitle(UNKNOWN_ACHIEVEMENT_TITLE);
+
+        assertFalse(result.isPresent());
+        verify(achievementRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getByTitle_shouldReturnEmptyWhenRepositoryIsEmpty() {
+        when(achievementRepository.findAll()).thenReturn(Collections.emptyList());
+
+        Optional<Achievement> result = dbAchievementSource.getByTitle(ACHIEVEMENT_TITLE_COLLECTOR);
+
+        assertFalse(result.isPresent());
+        verify(achievementRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getByTitle_shouldHandleNullTitleCorrectly() {
+        when(achievementRepository.findAll()).thenReturn(allAchievements);
+
+        // Act
+        Optional<Achievement> result = dbAchievementSource.getByTitle(null);
+
+        // Assert
+        assertFalse(result.isPresent());
+        verify(achievementRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getById_shouldReturnAchievementWhenExists() {
+        when(achievementRepository.findById(ACHIEVEMENT_ID_1)).thenReturn(Optional.of(achievementCollector));
+
+        Optional<Achievement> result = dbAchievementSource.getById(ACHIEVEMENT_ID_1);
+
+        assertTrue(result.isPresent());
+        assertEquals(ACHIEVEMENT_ID_1, result.get().getId());
+        assertEquals(ACHIEVEMENT_TITLE_COLLECTOR, result.get().getTitle());
+        verify(achievementRepository, times(1)).findById(ACHIEVEMENT_ID_1);
+    }
+
+    @Test
+    void getById_shouldReturnEmptyIfRepositoryIsEmpty() {
+        when(achievementRepository.findById(UNKNOWN_ID)).thenReturn(Optional.empty());
+
+        Optional<Achievement> result = dbAchievementSource.getById(UNKNOWN_ID);
+
+        assertFalse(result.isPresent());
+        verify(achievementRepository, times(1)).findById(UNKNOWN_ID);
+    }
+
+    @Test
+    void getAll_shouldCallRepositoryOnce() {
+        when(achievementRepository.findAll()).thenReturn(allAchievements);
+
+        dbAchievementSource.getAll();
+
+        verify(achievementRepository, times(1)).findAll();
+        verifyNoMoreInteractions(achievementRepository);
+    }
+
+    @Test
+    void getByTitle_shouldCallGetAllMethod() {
+        when(achievementRepository.findAll()).thenReturn(allAchievements);
+
+        dbAchievementSource.getByTitle("First Achievement");
+
+        verify(achievementRepository, times(1)).findAll();
+    }
+}

--- a/src/test/java/faang/school/achievement/source/DbAchievementSourceTest.java
+++ b/src/test/java/faang/school/achievement/source/DbAchievementSourceTest.java
@@ -16,13 +16,13 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-
 
 @ExtendWith(MockitoExtension.class)
 class DbAchievementSourceTest extends DataForTests {
@@ -54,50 +54,6 @@ class DbAchievementSourceTest extends DataForTests {
 
         assertNotNull(result);
         assertTrue(result.isEmpty());
-        verify(achievementRepository, times(1)).findAll();
-    }
-
-    @Test
-    void getByTitle_shouldReturnAchievementWhenExists() {
-        when(achievementRepository.findAll()).thenReturn(allAchievements);
-
-        Optional<Achievement> result = dbAchievementSource.getByTitle(ACHIEVEMENT_TITLE_COLLECTOR);
-
-        assertTrue(result.isPresent());
-        assertEquals(ACHIEVEMENT_ID_1, result.get().getId());
-        assertEquals(ACHIEVEMENT_TITLE_COLLECTOR, result.get().getTitle());
-        verify(achievementRepository, times(1)).findAll();
-    }
-
-    @Test
-    void getByTitle_shouldReturnEmptyWhenNotExists() {
-        when(achievementRepository.findAll()).thenReturn(allAchievements);
-
-        Optional<Achievement> result = dbAchievementSource.getByTitle(UNKNOWN_ACHIEVEMENT_TITLE);
-
-        assertFalse(result.isPresent());
-        verify(achievementRepository, times(1)).findAll();
-    }
-
-    @Test
-    void getByTitle_shouldReturnEmptyWhenRepositoryIsEmpty() {
-        when(achievementRepository.findAll()).thenReturn(Collections.emptyList());
-
-        Optional<Achievement> result = dbAchievementSource.getByTitle(ACHIEVEMENT_TITLE_COLLECTOR);
-
-        assertFalse(result.isPresent());
-        verify(achievementRepository, times(1)).findAll();
-    }
-
-    @Test
-    void getByTitle_shouldHandleNullTitleCorrectly() {
-        when(achievementRepository.findAll()).thenReturn(allAchievements);
-
-        // Act
-        Optional<Achievement> result = dbAchievementSource.getByTitle(null);
-
-        // Assert
-        assertFalse(result.isPresent());
         verify(achievementRepository, times(1)).findAll();
     }
 
@@ -134,11 +90,49 @@ class DbAchievementSourceTest extends DataForTests {
     }
 
     @Test
-    void getByTitle_shouldCallGetAllMethod() {
-        when(achievementRepository.findAll()).thenReturn(allAchievements);
+    void getByTitle_whenAchievementDoesNotExistShouldReturnEmptyOptional() {
 
-        dbAchievementSource.getByTitle("First Achievement");
+        when(achievementRepository.findByTitle(UNKNOWN_ACHIEVEMENT_TITLE))
+                .thenReturn(Optional.empty());
 
-        verify(achievementRepository, times(1)).findAll();
+        Optional<Achievement> result = dbAchievementSource.getByTitle(UNKNOWN_ACHIEVEMENT_TITLE);
+
+        assertFalse(result.isPresent());
+
+        verify(achievementRepository, times(1)).findByTitle(UNKNOWN_ACHIEVEMENT_TITLE);
+    }
+
+
+    @Test
+    void getByTitle_withDifferentTitlesShouldReturnDifferentResults() {
+
+        when(achievementRepository.findByTitle(ACHIEVEMENT_TITLE_COLLECTOR))
+                .thenReturn(Optional.of(achievementCollector));
+        when(achievementRepository.findByTitle(ACHIEVEMENT_TITLE_EXPERT))
+                .thenReturn(Optional.of(achievementExpert));
+
+        Optional<Achievement> result1 = dbAchievementSource.getByTitle(ACHIEVEMENT_TITLE_COLLECTOR);
+        Optional<Achievement> result2 = dbAchievementSource.getByTitle(ACHIEVEMENT_TITLE_EXPERT);
+
+        assertTrue(result1.isPresent());
+        assertTrue(result2.isPresent());
+        assertEquals(result1.get().getId(), ACHIEVEMENT_ID_1);
+        assertEquals(result2.get().getId(), ACHIEVEMENT_ID_3);
+        assertNotEquals(result1.get(), result2.get());
+    }
+
+    @Test
+    void getByTitle_ShouldReturnSameOptionalOnMultipleCalls() {
+        when(achievementRepository.findByTitle(ACHIEVEMENT_TITLE_COLLECTOR))
+                .thenReturn(Optional.of(achievementCollector));
+
+        Optional<Achievement> result1 = dbAchievementSource.getByTitle(ACHIEVEMENT_TITLE_COLLECTOR);
+        Optional<Achievement> result2 = dbAchievementSource.getByTitle(ACHIEVEMENT_TITLE_COLLECTOR);
+
+        assertTrue(result1.isPresent());
+        assertTrue(result2.isPresent());
+        assertEquals(result1.get(), result2.get());
+
+        verify(achievementRepository, times(2)).findByTitle(ACHIEVEMENT_TITLE_COLLECTOR);
     }
 }


### PR DESCRIPTION
Задание
achievement_service будет в перспективе получать очень много разнообразных событий из прочих сервисов. Чем больше пользователей, тем больше событий. Это значит, что achievement_service будет постоянно обращаться в БД для проверки тех или иных достижений.

Однако, достижения по своим названиям и описаниям являются фиксированным набором. Их количество меняется только тогда, когда разработчики добавляют новые в систему. Соответственно, изменения происходят крайне редко.

Раз уж achievement_service будет очень часто обращаться к этим достижениям, меняются они редко, а также они занимают относительно немного места в памяти, то их набор — это идеальный кандидат для кэширования в памяти achievement_service.

В результате achievement_service сможет обращаться в кэш достижений вместо того, чтобы каждый раз ходить в БД на каждом внешнем событии. Это значительно повысит производительность системы и снизит нагрузку на БД.

Задача
Создать класс AchievementCache. Это будет основной класс, содержащий в себе все кэшированные достижения, а также предоставляющий методы для удобного получения достижения из кэша.

В AchievementCache должно быть поле, в котором и хранятся все доступные в системе достижения. Это должна быть некоторая структура данных, из которой можно будет очень быстро получить объект Achievement по его полю title. В какой структуре данных можно было бы хранить достижения в таком виде?

Также в AchievementCache должен быть метод get, который принимает название достижения, а возвращает объект Achievement с соответствующим названием из кэша — структуры данных из пункта выше.

Прямо сейчас кэш внутри AchievementCache будет, разумеется, пуст. Его необходимо заполнить. Нужно, чтобы при запуске achievement_service кэш сразу заполнялся всеми необходимыми данными из БД. Для этого:
4.1 Используем готовый бин AchievementRepository и его метод findAll, который возвращает все достижения, доступные в БД.
4.2Используем аннотацию @PostConstruct, чтобы создать метод инициализации кэша при старте всего сервиса.